### PR TITLE
fix: Incorrect processing of rules for plugins with the "-" sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,15 @@ Policy notes:
 - `id`: optional identifier for audit readability.
 - `action`: currently `exec` or `socket`.
 - `decision`: `allow`, `deny`, `prompt_once`.
-- `actor`: plugin name/pattern (best-effort attribution).
+- `actor`: exact plugin name match (best-effort attribution).
+- `actor_pattern`: Lua pattern or `/vim-regex/` match for actor when exact match is too narrow.
 - `exe`: executable basename (`curl`, `git`, `rg`, ...).
 - `args_any`: match if any listed argument is present.
 - `target_pattern`: pattern/regex-like check against normalized target.
+
+Compatibility note:
+- Legacy configs that used pattern-like values in `actor` still work for now.
+- Those rules emit a warning and should be migrated to `actor_pattern`.
 
 ### prompt_once semantics
 - On first match, user is prompted with Allow/Deny.

--- a/lua/nvim_sandman/policy/config.lua
+++ b/lua/nvim_sandman/policy/config.lua
@@ -77,8 +77,24 @@ local function validate_rule(rule, idx)
     error(('nvim-sandman: policy rule #%d has invalid decision'):format(idx))
   end
 
+  if rule.actor and type(rule.actor) ~= 'string' then
+    error(('nvim-sandman: policy rule #%d actor must be a string'):format(idx))
+  end
+
+  if rule.actor_pattern and type(rule.actor_pattern) ~= 'string' then
+    error(('nvim-sandman: policy rule #%d actor_pattern must be a string'):format(idx))
+  end
+
+  if rule.exe and type(rule.exe) ~= 'string' then
+    error(('nvim-sandman: policy rule #%d exe must be a string'):format(idx))
+  end
+
   if rule.args_any and type(rule.args_any) ~= 'table' then
     error(('nvim-sandman: policy rule #%d args_any must be a list'):format(idx))
+  end
+
+  if rule.target_pattern and type(rule.target_pattern) ~= 'string' then
+    error(('nvim-sandman: policy rule #%d target_pattern must be a string'):format(idx))
   end
 end
 

--- a/lua/nvim_sandman/policy/engine.lua
+++ b/lua/nvim_sandman/policy/engine.lua
@@ -1,6 +1,6 @@
 local M = {}
-
 local MAGIC_PATTERN = '[%^%$%(%)%%%.%[%]%*%+%-%?]'
+local warned_legacy_actor_patterns = {}
 
 local function basename(path)
   if type(path) ~= 'string' then
@@ -11,7 +11,20 @@ local function basename(path)
   return normalized:match('([^/]+)$') or normalized
 end
 
-local function match_value(expected, actual)
+local function match_exact(expected, actual)
+  if expected == nil then
+    return true
+  end
+
+  if type(expected) ~= 'string' then
+    return false
+  end
+
+  actual = tostring(actual or '')
+  return actual == expected
+end
+
+local function match_pattern(expected, actual)
   if expected == nil then
     return true
   end
@@ -32,11 +45,29 @@ local function match_value(expected, actual)
     end
   end
 
-  if expected:find(MAGIC_PATTERN) then
-    return actual:find(expected) ~= nil
+  return actual:find(expected) ~= nil
+end
+
+local function looks_like_pattern(value)
+  return type(value) == 'string' and value:find(MAGIC_PATTERN) ~= nil
+end
+
+local function warn_legacy_actor_pattern(actor)
+  if warned_legacy_actor_patterns[actor] then
+    return
   end
 
-  return actual == expected
+  warned_legacy_actor_patterns[actor] = true
+
+  if vim and vim.notify and vim.log and vim.log.levels and vim.log.levels.WARN then
+    vim.notify(
+      string.format(
+        'nvim-sandman: policy rule actor=%q is using deprecated implicit pattern matching; use actor_pattern instead',
+        actor
+      ),
+      vim.log.levels.WARN
+    )
+  end
 end
 
 local function match_args_any(expected_args, actual_args)
@@ -67,7 +98,17 @@ local function match_rule(rule, req)
     return false
   end
 
-  if rule.actor and not match_value(rule.actor, req.actor) then
+  if rule.actor then
+    if not match_exact(rule.actor, req.actor) then
+      if rule.actor_pattern or not looks_like_pattern(rule.actor) or not match_pattern(rule.actor, req.actor) then
+        return false
+      end
+
+      warn_legacy_actor_pattern(rule.actor)
+    end
+  end
+
+  if rule.actor_pattern and not match_pattern(rule.actor_pattern, req.actor) then
     return false
   end
 
@@ -79,7 +120,7 @@ local function match_rule(rule, req)
     return false
   end
 
-  if rule.target_pattern and not match_value(rule.target_pattern, req.target) then
+  if rule.target_pattern and not match_pattern(rule.target_pattern, req.target) then
     return false
   end
 

--- a/site/index.md
+++ b/site/index.md
@@ -173,6 +173,12 @@ Check:
 Prompt cache key includes target. Slight command differences can trigger new prompts.
 Use explicit stable `allow` / `deny` rules for frequent commands.
 
+### Actor rules with hyphens do not match
+
+Use `actor` for exact plugin names such as `fzf-lua` or `nvim-treesitter`.
+Use `actor_pattern` only when you intentionally want pattern matching.
+Legacy pattern-like `actor` values still work temporarily, but they warn and should be migrated.
+
 ## FAQ
 
 ### Does it block tools started outside Neovim?

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -117,6 +117,11 @@ local function load_core()
   return require('nvim_sandman.core')
 end
 
+local function load_policy_engine()
+  package.loaded['nvim_sandman.policy.engine'] = nil
+  return require('nvim_sandman.policy.engine')
+end
+
 local function assert_eq(actual, expected, msg)
   if actual ~= expected then
     error(string.format('%s\nexpected: %s\nactual: %s', msg, tostring(expected), tostring(actual)))
@@ -330,6 +335,102 @@ test('file stats storage persists between setup calls', function()
 
   assert_eq(core_reloaded.stats().total.attempts, 1, 'second session should restore attempts from file')
   os.remove(stats_path)
+end)
+
+test('policy actor literal with hyphen matches exactly', function()
+  reset_vim()
+  local engine = load_policy_engine()
+
+  local result = engine.evaluate({
+    action = 'exec',
+    actor = 'fzf-lua',
+    exe = 'fzf',
+    args = {},
+    target = 'fzf --version',
+  }, {
+    default = 'prompt_once',
+    rules = {
+      { id = 'allow-fzf', action = 'exec', actor = 'fzf-lua', decision = 'allow' },
+    },
+  })
+
+  assert_eq(result.decision, 'allow', 'literal actor rule should match exact hyphenated actor name')
+  assert_eq(result.rule_id, 'allow-fzf', 'literal actor rule should win over default policy')
+end)
+
+test('policy exact actor match wins without legacy warning', function()
+  reset_vim()
+  local engine = load_policy_engine()
+  local warned = nil
+  vim.notify = function(message, level)
+    warned = { message = message, level = level }
+  end
+
+  local result = engine.evaluate({
+    action = 'exec',
+    actor = 'fzf-lua',
+    exe = 'git',
+    args = {},
+    target = 'git fetch',
+  }, {
+    default = 'prompt_once',
+    rules = {
+      { id = 'allow-fzf', action = 'exec', actor = 'fzf-lua', decision = 'allow' },
+    },
+  })
+
+  assert_eq(result.decision, 'allow', 'exact actor match should still succeed')
+  assert_eq(result.rule_id, 'allow-fzf', 'exact actor rule should match directly')
+  assert_eq(warned, nil, 'exact actor match should not emit legacy compatibility warning')
+end)
+
+test('policy actor_pattern matches by lua pattern', function()
+  reset_vim()
+  local engine = load_policy_engine()
+
+  local result = engine.evaluate({
+    action = 'exec',
+    actor = 'nvim-treesitter',
+    exe = 'git',
+    args = {},
+    target = 'git fetch',
+  }, {
+    default = 'prompt_once',
+    rules = {
+      { id = 'allow-treesitter', action = 'exec', actor_pattern = 'nvim%-tree.*', decision = 'allow' },
+    },
+  })
+
+  assert_eq(result.decision, 'allow', 'actor_pattern should support lua pattern matching')
+  assert_eq(result.rule_id, 'allow-treesitter', 'actor_pattern rule should match request actor')
+end)
+
+test('policy legacy actor pattern remains compatible with warning', function()
+  reset_vim()
+  local warned = nil
+  vim.notify = function(message, level)
+    warned = { message = message, level = level }
+  end
+
+  local engine = load_policy_engine()
+
+  local result = engine.evaluate({
+    action = 'exec',
+    actor = 'nvim-treesitter',
+    exe = 'git',
+    args = {},
+    target = 'git fetch',
+  }, {
+    default = 'prompt_once',
+    rules = {
+      { id = 'legacy-treesitter', action = 'exec', actor = 'nvim%-tree.*', decision = 'allow' },
+    },
+  })
+
+  assert_eq(result.decision, 'allow', 'legacy actor pattern should remain supported for compatibility')
+  assert_eq(result.rule_id, 'legacy-treesitter', 'legacy actor pattern should still match request actor')
+  assert_eq(type(warned), 'table', 'legacy actor pattern should emit deprecation warning')
+  assert_eq(warned.level, vim.log.levels.WARN, 'legacy actor pattern warning should use WARN level')
 end)
 
 local passed = 0


### PR DESCRIPTION
## Summary

This PR fixes policy rule matching for plugin actors such as `fzf-lua`, `nvim-treesitter`, and `nvim-lint`.

Previously, `match_value()` treated any `actor` containing Lua pattern metacharacters like `-` as a pattern. That caused exact actor rules such as:

```lua
{ id = "allow-fzf", action = "exec", actor = "fzf-lua", decision = "allow" }
```

to miss and fall through to `policy.default`.

## What changed

- `actor` matching now prefers exact string equality, so literal plugin names with `-` work as expected.
- Added explicit `actor_pattern` support for intentional actor pattern matching.
- Kept backward compatibility for existing configs that used pattern-like values in `actor`.
- Added a one-time warning for legacy implicit actor pattern usage, guiding users to migrate to `actor_pattern`.
- Tightened policy rule validation for `actor`, `actor_pattern`, `exe`, and `target_pattern`.
- Updated docs to clarify exact-vs-pattern semantics.

## Compatibility

This PR is backward-compatible:

- Exact actor rules like `actor = "fzf-lua"` now work correctly.
- Existing pattern-like actor rules such as `actor = "nvim%-tree.*"` still work for now.
- Legacy implicit actor patterns emit a warning and should be migrated to `actor_pattern`.

Recommended migration:

```lua
{ id = "allow-ts", action = "exec", actor_pattern = "nvim%-tree.*", decision = "allow" }
```